### PR TITLE
Clamp menu to screen

### DIFF
--- a/ui/TheMenu.lua
+++ b/ui/TheMenu.lua
@@ -125,6 +125,7 @@ function TheMenu:toggle()
     else
         play(SND.OPEN)
         self:Show()
+        self:SetClampedToScreen( true )
     end
 end
 


### PR DESCRIPTION
This will keep the menu window positioned on the screen when open regardless of where the button is positioned. There's a visual artifact when the menu overlaps with the button, in that the scrollbar is on top of the button, which otherwise is on top of the menu. It's all usable but not visually ideal. I can tweak that if you like. I figure it's unlikely to be hit very often as it would mean the button is positioned near the top of the screen, and in that case really it'd be better to detect that and anchor the menu to the bottom of the button instead. That would be significantly more invasive code-wise, though.